### PR TITLE
set correct header

### DIFF
--- a/proxy-simple.php
+++ b/proxy-simple.php
@@ -77,6 +77,10 @@ if( FALSE === $ret ) {
         error("Cannot get $url .");
 }
 
+/* 7. Set response_header to received header */ 
+foreach ($http_response_header as $header) {
+	header($header);
+}
 
 /* 8. Show */
 echo $ret;


### PR DESCRIPTION
The problem is that some headers aren't correctly set.

Try to proxy a .jpeg file
The 
"content-type" is "document"
it should be "image/jpeg"

The result is that the browser can't display the file. (If you only try to access the image directly)

As i am not sure if/ where the headers are stored in the cache i didn't modify the other file.
